### PR TITLE
Adds footer to hackathon page

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -97,11 +97,12 @@ const useStyles = makeStyles(
         background: theme.palette.primary.main,
       },
       '&:hover': {
-        background: theme.palette.secondary.main,
-        color: theme.palette.secondary.contrastText,
+        background: theme.palette.lowlight.main,
+        color: theme.palette.highlight.contrastText,
       },
-      '&:active, &:focus': {
-        background: theme.palette.secondary.light,
+      '&:active, &:focus, &:visited': {
+        background: theme.palette.lowlight.light,
+        color: theme.palette.highlight.contrastText,
       },
     },
     raisedSmall: {

--- a/modules/footer/FooterCTA.tsx
+++ b/modules/footer/FooterCTA.tsx
@@ -1,4 +1,5 @@
-import { Typography, Grid } from '@material-ui/core';
+import { Typography, Grid, GridSize } from '@material-ui/core';
+import LaunchIcon from '@material-ui/icons/Launch';
 import { makeStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 import Link from 'next/link';
@@ -13,6 +14,7 @@ type Props = {
   hideVolunteer?: boolean;
   hideSponsor?: boolean;
   noMinHeight?: boolean;
+  layoutThreeCols?: boolean;
 };
 
 const useStyles = makeStyles(
@@ -52,6 +54,23 @@ const useStyles = makeStyles(
     button: {
       width: '100%',
     },
+    containerThreeColHeading: {
+      maxWidth: '30rem',
+      margin: `0 auto ${theme.spacing(6)}px`,
+    },
+    containerThreeColItem: {
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+      height: '100%',
+    },
+    typographyThreeCol: {
+      marginBottom: theme.spacing(2),
+      fontSize: '1.1em',
+    },
+    spanNoBreak: {
+      display: 'inline-block',
+    },
   })
 );
 
@@ -60,8 +79,14 @@ const FooterCTA = ( props: Props ): ReactElement => {
     hideVolunteer = false,
     hideSponsor = false,
     noMinHeight = false,
+    layoutThreeCols = false,
   } = props;
   const classes = useStyles();
+
+  let directoryColWidth: GridSize = hideVolunteer || hideSponsor ? 6 : 4;
+  if (hideSponsor && hideVolunteer) {
+    directoryColWidth = 12;
+  }
 
   return (
     <section
@@ -73,64 +98,177 @@ const FooterCTA = ( props: Props ): ReactElement => {
       )}
     >
       <div className={classes.container}>
-        <Typography variant="h1" className={classes.typographyH1}>
-          We can&rsquo;t close the technology gender gap without your help.
-        </Typography>
-        <Typography>
-          Join us in making the technology sector in Newfoundland &amp; Labrador as diverse, resilient and creative as the people who live here.
-        </Typography>
-        <div className={classes.containerButtons}>
-          <Grid
-            className={classes.gridContainer}
-            spacing={4}
-            container
-          >
-            {
-              hideVolunteer
-                ? null
-                : (
+        {
+          layoutThreeCols
+            ? (
+              <>
+                <div className={classes.containerThreeColHeading}>
+                  <Typography variant="h1" className={classes.typographyH1}>
+                    Help us build an inclusive tech community.
+                  </Typography>
+                  <Typography>
+                    If you don&rsquo;t meet the eligibility criteria to participate in Digital Waves, there are still many ways you can contribute.
+                  </Typography>
+                </div>
+                <Grid
+                  className={classes.gridContainer}
+                  spacing={7}
+                  container
+                >
                   <Grid
                     item
                     xs={12}
-                    sm={hideSponsor ? 12 : 6}
+                    md={directoryColWidth}
                   >
-                    <Link href="/volunteer">
+                    <div className={classes.containerThreeColItem}>
+                      <Typography className={classes.typographyThreeCol}>
+                        Know of a queer
+                        <span className={classes.spanNoBreak}>-owned</span>
+                        &nbsp;or
+                        <span className={classes.spanNoBreak}>-inclusive</span>
+                        &nbsp;business, organization, or professional?
+                        Suggest a listing to be highlighted in our 2023 program.
+                      </Typography>
                       <Button
                         className={classes.button}
                         component="a"
                         variant="raised"
-                        color="highlight"
+                        color="lowlight"
+                        href="https://inqueeries.ca"
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore
+                        target="_blank"
+                        rel="nopener noreferrer"
+                        endIcon={
+                          <LaunchIcon />
+                        }
                       >
-                        Volunteer With Us
+                        Suggest a Listing
                       </Button>
-                    </Link>
+                    </div>
                   </Grid>
-                )
-            }
-            {
-              hideSponsor
-                ? null
-                : (
+                  {
+                    hideVolunteer
+                      ? null
+                      : (
+                        <Grid
+                          item
+                          xs={12}
+                          md={hideSponsor ? 6 : 4}
+                        >
+                          <div className={classes.containerThreeColItem}>
+                            <Typography className={classes.typographyThreeCol}>
+                              Interested in helping with Digital Waves programs? All skills and expertise needed - 
+                              planners, designers, coders, marketers, and so much more.
+                            </Typography>
+                            <Link href="/volunteer">
+                              <Button
+                                className={classes.button}
+                                component="a"
+                                variant="raised"
+                                color="highlight"
+                              >
+                                Volunteer With Us
+                              </Button>
+                            </Link>
+                          </div>
+                        </Grid>
+                      )
+                  }
+                  {
+                    hideSponsor
+                      ? null
+                      : (
+                        <Grid
+                          item
+                          xs={12}
+                          md={hideVolunteer ? 6 : 4}
+                        >
+                          <div className={classes.containerThreeColItem}>
+                            <Typography className={classes.typographyThreeCol}>
+                              By sponsoring this program you&rsquo;re helping provide life-changing experiences to 
+                              those who are underrepresented in the tech sector.
+                            </Typography>
+                            <Link href="/volunteer">
+                              <Button
+                                className={classes.button}
+                                component="a"
+                                variant="raised"
+                                color="secondary"
+                              >
+                                Sponsor Us
+                              </Button>
+                            </Link>
+                          </div>
+                        </Grid>
+                      )
+                  }
+                </Grid>
+              </>
+            )
+            : (
+              <>
+                <Typography variant="h1" className={classes.typographyH1}>
+                  We can&rsquo;t close the technology gender gap without your help.
+                </Typography>
+                <Typography>
+                  Join us in making the technology sector in Newfoundland &amp; Labrador as diverse, resilient and creative as the people who live here.
+                </Typography>
+                <div className={classes.containerButtons}>
                   <Grid
-                    item
-                    xs={12}
-                    sm={hideVolunteer ? 12 : 6}
+                    className={classes.gridContainer}
+                    spacing={4}
+                    container
                   >
-                    <Link href="/volunteer">
-                      <Button
-                        className={classes.button}
-                        component="a"
-                        variant="raised"
-                        color="secondary"
-                      >
-                        Sponsor Us
-                      </Button>
-                    </Link>
+                    {
+                      hideVolunteer
+                        ? null
+                        : (
+                          <Grid
+                            item
+                            xs={12}
+                            sm={hideSponsor ? 12 : 6}
+                          >
+                            <Link href="/volunteer">
+                              <Button
+                                className={classes.button}
+                                component="a"
+                                variant="raised"
+                                color="highlight"
+                              >
+                                Volunteer With Us
+                              </Button>
+                            </Link>
+                          </Grid>
+                        )
+                    }
+                    {
+                      hideSponsor
+                        ? null
+                        : (
+                          <Grid
+                            item
+                            xs={12}
+                            sm={hideVolunteer ? 12 : 6}
+                          >
+                            <Link href="/volunteer">
+                              <Button
+                                className={classes.button}
+                                component="a"
+                                variant="raised"
+                                color="secondary"
+                              >
+                                Sponsor Us
+                              </Button>
+                            </Link>
+                          </Grid>
+                        )
+                    }
                   </Grid>
-                )
-            }
-          </Grid>
-        </div>
+                </div>
+              </>
+            )
+        }
       </div>
     </section>
   );

--- a/modules/hackathon-2023/Hackathon2023Footer.tsx
+++ b/modules/hackathon-2023/Hackathon2023Footer.tsx
@@ -1,10 +1,9 @@
 import { ReactElement } from 'react';
+import FooterCTA from '../footer/FooterCTA';
 
 const Hackathon2023Footer = (): ReactElement => {
   return (
-    <div>
-      Hackathon2023Footer
-    </div>
+    <FooterCTA layoutThreeCols={true} />
   );
 };
 

--- a/pages/hackathon-2023.tsx
+++ b/pages/hackathon-2023.tsx
@@ -6,7 +6,7 @@ import Hackathon2023Hero from '../modules/hackathon-2023/Hackathon2023Hero';
 import Hackathon2023ProgramInfo from '../modules/hackathon-2023/Hackathon2023ProgramInfo';
 import Hackathon2023Register from '../modules/hackathon-2023/Hackathon2023Register';
 import Hackathon2023FAQ from '../modules/hackathon-2023/Hackathon2023FAQ';
-import Hackathon2023Footer from '../modules/footer/Hackathon2023Footer';
+import Hackathon2023Footer from '../modules/hackathon-2023/Hackathon2023Footer';
 import Footer from '../modules/footer/Footer';
 import FooterSubscribe from '../modules/footer/FooterSubscribe';
 


### PR DESCRIPTION
- New `FooterCTA` prop `layoutThreeCols` toggles three column layout to support "Suggest a Listing" CTA and contextual info to volunteer and sponsor CTAs
- Some minor changes to `Button` to fix styling issues on raised lowlight variant

![Screen Shot 2023-01-21 at 2 36 57 PM](https://user-images.githubusercontent.com/3619483/213880865-6aec4a8a-0d25-48be-8629-b7225f69ede1.png)
